### PR TITLE
Proposition to remove mandatory dependancies and to use summary for description meta-tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.2.0
+##  03/06/2017
+
+1. [](#improved)
+    * Remove mandatory dependencies to AboutMe plugin for twitter:site integration
+    * Use summary for meta-tag description instead content for description
+
 # v0.1.0
 ##  09/28/2016
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add all Meta Tags that need Facebook Open Graph, and Twitter Cards.
 
 * [Open Graph](http://ogp.me/) support.
 * [Twitter Cards](https://dev.twitter.com/cards/overview) support. You can select between Summary and Large cards.
-* [AboutMe plugin](https://github.com/Birssan/grav-plugin-about-me) integration.
+* [AboutMe plugin](https://github.com/Birssan/grav-plugin-about-me) integration possibility.
 
 
 # Installation
@@ -33,7 +33,8 @@ Just enable plugin, no need edit any template. :)
 
 ## Associate Twitter account
 
-Social-Meta-Tags need [AboutMe plugin](https://github.com/Birssan/grav-plugin-about-me). To add/change the Twitter defined in `twitter:site`, edit your profile in the AboutMe plugin.
+Social-Meta-Tags can use [AboutMe plugin](https://github.com/Birssan/grav-plugin-about-me) min version 1.1.4. To add/change the Twitter defined in `twitter:site`, edit your profile in the AboutMe plugin.
+However, you have possibility to link `twitter:site` without using AboutMe plugin.
 
 ## Facebook App Id
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -12,9 +12,6 @@ bugs: https://github.com/tucho235/grav-plugin-social-meta-tags/issues
 docs: https://github.com/tucho235/grav-plugin-social-meta-tags/blob/develop/README.md
 license: MIT
 
-dependencies:
-    - { name: aboutme, version: '~1.1.4' }
-
 form:
   validation: strict
   fields:
@@ -60,6 +57,22 @@ form:
                     options:
                       summary_large_image: PLUGINS.SOCIAL_META_TAGS.TWITTER.TYPE_CARDS.LARGE
                       summary: PLUGINS.SOCIAL_META_TAGS.TWITTER.TYPE_CARDS.SUMMARY
+                  social_pages.pages.twitter.aboutme:
+                    type: toggle
+                    label: PLUGINS.SOCIAL_META_TAGS.TWITTER.ABOUTME
+                    highlight: 1
+                    default: 0
+                    options:
+                      1: PLUGINS.SOCIAL_META_TAGS.YES
+                      0: PLUGINS.SOCIAL_META_TAGS.NO
+                    validate:
+                      type: bool
+                  social_pages.pages.twitter.username:
+                    type: text
+                    label: PLUGINS.SOCIAL_META_TAGS.TWITTER.USERNAME
+                    help: PLUGINS.SOCIAL_META_TAGS.TWITTER.USERNAME_HELP
+                    size: small
+                    placeholder: '@'
               facebook:
                 type: tab
                 title: PLUGINS.SOCIAL_META_TAGS.FACEBOOK.NAME

--- a/languages.yaml
+++ b/languages.yaml
@@ -19,6 +19,9 @@ en:
         TYPE_CARDS:
           LARGE: 'Summary Card with Large Image'
           SUMMARY: 'Summary Card'
+        ABOUTME: 'Use AboutMe Plugin'
+        USERNAME: 'Username'
+        USERNAME_HELP: 'If you not use AboutMe plugin, please define your twitter username (@username)'
 
       FACEBOOK:
         NAME: 'Facebook Open Graph'
@@ -48,6 +51,9 @@ es:
         TYPE_CARDS:
           LARGE: 'Tarjetas de Resumen con imagen grande'
           SUMMARY: 'Tarjetas de Resumen'
+        ABOUTME: 'Utilizar el plugin aboutMe'
+        USERNAME: 'Nombre del usuario'
+        USERNAME_HELP: 'Si no se utiliza aboutMe plugin, por favor, defina el nombre de usuario de Twitter'
 
       FACEBOOK:
         NAME: 'Facebook Open Graph'
@@ -77,6 +83,9 @@ fr:
         TYPE_CARDS:
           LARGE: 'Carte de résumé avec grande image'
           SUMMARY: 'Carte de résumé'
+        ABOUTME: 'Utiliser le plugin AboutMe'
+        USERNAME: 'Nom d''utilisateur'
+        USERNAME_HELP: 'Si le plugin AboutMe n''est pas utilisé, veuillez définir le nom d''utilisateur Twitter SVP'
 
       FACEBOOK:
         NAME: 'Facebook Open Graph'
@@ -106,6 +115,9 @@ de:
         TYPE_CARDS:
           LARGE: 'Karte mit einer Zusammenfassung und großem Bild'
           SUMMARY: 'Karte mit einer Zusammenfassung'
+        ABOUTME: 'Verwenden Sie das Plugin AboutMe'
+        USERNAME: 'Benutzername'
+        USERNAME_HELP: 'Wenn AboutMe Plugin nicht verwendet wird, setzen Sie bitte die Twitter-Benutzernamen bitte'
 
       FACEBOOK:
         NAME: 'Facebook Open Graph'

--- a/social-meta-tags.php
+++ b/social-meta-tags.php
@@ -73,7 +73,7 @@ class SocialMetaTagsPlugin extends Plugin
             if (!isset($meta['twitter:description'])) {
                 $meta['twitter:description']['name']     = 'twitter:description';
                 $meta['twitter:description']['property'] = 'twitter:description';
-                $meta['twitter:description']['content']  = $this->sanitizeMarkdowns($this->grav['page']->value('content'));
+                $meta['twitter:description']['content']  = $this->sanitizeMarkdowns(strip_tags($this->grav['page']->summary()));
             }
 
             if (!isset($meta['twitter:image'])) {
@@ -88,14 +88,28 @@ class SocialMetaTagsPlugin extends Plugin
             }
 
             if (!isset($meta['twitter:site'])) {
-                if ($this->grav['config']->get('plugins.aboutme.social_pages.enabled')
-                    and $this->grav['config']->get('plugins.aboutme.social_pages.pages.twitter.url')
-                ) {
-                    $user = preg_replace('((http|https)://twitter.com/)', '@', $this->grav['config']->get('plugins.aboutme.social_pages.pages.twitter.url'));
-                    $meta['twitter:site']['name']     = 'twitter:site';
-                    $meta['twitter:site']['property'] = 'twitter:site';
-                    $meta['twitter:site']['content']  = $user;
+                //Use AboutMe plugin configuration
+                if ($this->grav['config']->get('plugins.social-meta-tags.social_pages.pages.twitter.aboutme'))
+                {
+                    if ($this->grav['config']->get('plugins.aboutme.social_pages.enabled')
+                         and $this->grav['config']->get('plugins.aboutme.social_pages.pages.twitter.url'))
+                    {
+                        $user = preg_replace('((http|https)://twitter.com/)', '@', $this->grav['config']->get('plugins.aboutme.social_pages.pages.twitter.url'));
+                    }
+                    else
+                    {
+                        $user = "";
+                    }
                 }
+                //Use plugin self-configuration
+                else
+                {
+                    $user = "@".$this->grav['config']->get('plugins.social-meta-tags.social_pages.pages.twitter.username');
+                }
+                //Update data
+                $meta['twitter:site']['name']     = 'twitter:site';
+                $meta['twitter:site']['property'] = 'twitter:site';
+                $meta['twitter:site']['content']  = $user;
             }
         }
         return $meta;
@@ -115,7 +129,7 @@ class SocialMetaTagsPlugin extends Plugin
 
             $meta['og:description']['name']     = 'og:description';
             $meta['og:description']['property'] = 'og:description';
-            $meta['og:description']['content']  = $this->sanitizeMarkdowns($this->grav['page']->value('content'));
+            $meta['og:description']['content']  = $this->sanitizeMarkdowns(strip_tags($this->grav['page']->summary()));
 
             $meta['og:type']['name']            = 'og:type';
             $meta['og:type']['property']        = 'og:type';

--- a/social-meta-tags.yaml
+++ b/social-meta-tags.yaml
@@ -4,6 +4,8 @@ social_pages:
     twitter:
       enabled: true
       type: summary
+      aboutme: false
+      username: ''
     facebook:
       enabled: false
       appid: '1234567890'


### PR DESCRIPTION
Hello,
Because I not use AboutMe plugin, I propose this improvement:
  - Remove mandatory dependancies to AboutMe ~1.1.4 
  - Possibility to configure Twitter username via admin panel if we want to not use AboutMe

So more, I propose to use page.summary fo fill description meta-tag instead page.content. Using content, you will have data truncated with 140 chars. Using summary, if summary is lower than 140 chars, you will get only the summary. So I think this is better.

Thanks :)

Note: I not found if there is possibility to define optional dependancies in blueprints.yaml. If is the case, it is better to use this implementation.